### PR TITLE
Improve image prompt. Add secrets hiding.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# API Keys. This is a cheap-and-dirty way to keep API keys out of git
+# until we build a backend to store them.
+/lib/auth/secrets.dart

--- a/lib/data/open_ai.dart
+++ b/lib/data/open_ai.dart
@@ -1,12 +1,17 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../auth/secrets.dart';
 
 class OpenAi{
 
   Future<String> getMessages(List<dynamic> messages) async {
     const String authority = 'api.openai.com';
     const String path = 'v1/chat/completions';
-    const String apiKey = 'API-KEY';
+    // Cheap-and-dirty secrets hiding until there's a back-end to store them.
+    // You should create a file called lib/auth/secrets.dart and add the following:
+    //   const String openaiApiKey = "API-KEY";
+    // where API-KEY is your OpenAI API key.
+    const String apiKey = openaiApiKey;
     Map<String, String> headers = {
         "Content-Type": "application/json",
         "Authorization": "Bearer $apiKey",
@@ -24,14 +29,66 @@ class OpenAi{
 
     Uri uri = Uri.https(authority, path);
     http.Response result = await http.post(uri, headers: headers, body: json.encode(parameters));
+
+    // If we got an error (result.body.error is not null), return the error.
+    // Otherwise, return the response.
     Map<String, dynamic> data = json.decode(result.body);
-    return data['choices'][0]['message']['content'];
+    if (data['error'] != null) {
+      return data['error']['message'];
+    } else {
+      return data['choices'][0]['message']['content'];
+    }
+  }
+
+  Future<String> getImagePrompt(String story, String latestMessage) async {
+    const String authority = 'api.openai.com';
+    const String path = 'v1/chat/completions';
+    // Cheap-and-dirty secrets hiding until there's a back-end to store them.
+    // You should create a file called lib/auth/secrets.dart and add the following:
+    //   const String openaiApiKey = "API-KEY";
+    // where API-KEY is your OpenAI API key.
+    const String apiKey = openaiApiKey;
+    Map<String, String> headers = {
+      "Content-Type": "application/json",
+      "Authorization": "Bearer $apiKey",
+    };
+    List messages = [];
+    String content = '''Generate a Dall-E prompt for the following scene, limiting the prompt to 400 characters: $story
+    
+    $latestMessage''';
+    messages.add({
+      'role': 'user',
+      'type': 'text',
+      'content': content
+    });
+    Map<String, dynamic> parameters = {
+      'model': 'gpt-3.5-turbo',
+      "temperature": 0.7,
+      "messages": messages,
+    };
+
+    // remove type from messages
+    for (var message in messages) {
+      message.remove('type');
+    }
+    Uri uri = Uri.https(authority, path);
+    http.Response result = await http.post(uri, headers: headers, body: json.encode(parameters));
+    Map<String, dynamic> data = json.decode(result.body);
+    if (data['error'] != null) {
+      return data['error']['message'];
+    } else {
+      return data['choices'][0]['message']['content'];
+    }
   }
 
   Future<String> getImage(String prompt) async {
     const String authority = 'api.openai.com';
     const String path = 'v1/images/generations';
-    const String apiKey = 'API-KEY';
+    // Cheap-and-dirty secrets hiding until there's a back-end to store them.
+    // You should create a file called lib/auth/secrets.dart and add the following:
+    //   const String openaiApiKey = "API-KEY";
+    // where API-KEY is your OpenAI API key.
+    const String apiKey = openaiApiKey;
     Map<String, String> headers = {
         "Content-Type": "application/json",
         "Authorization": "Bearer $apiKey",

--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -89,15 +89,21 @@ class _ChatScreebState extends State<ChatScreen> {
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(content: Text('Generating Response')),
                     );
+                    // todo: Scrolling doesn't work correctly on the Open iOS Simulator.
+                    // todo: Convert the "what do you see?" prompt to a button or icon. 3D glasses, maybe?
                     if (nextAction == 'what do you see?') {
                       print('generating image');
-                      print(messages[messages.length-2]['content']);
-                      openAi.getImage(messages[messages.length-2]['content']).then((value) {
-                        messages.add({'role': 'system', 'type': 'image', 'content': value});
-                        setState(() {
-                          messages = messages;
+                      print('messages[len-2][content]: ' + messages[messages.length-2]['content']);
+                      print('messages[len-1][content]: ' + messages[messages.length-1]['content']);
+                      openAi.getImagePrompt(messages[messages.length-2]['content'], nextAction).then((prompt) {
+                        print("new image prompt: $prompt");
+                        openAi.getImage(prompt).then((value) {
+                          messages.add({'role': 'system', 'type': 'image', 'content': value});
+                          setState(() {
+                            messages = messages;
+                          });
+                          ScaffoldMessenger.of(context).hideCurrentSnackBar();
                         });
-                        ScaffoldMessenger.of(context).hideCurrentSnackBar();
                       });
                     }else{
                       openAi.getMessages(messages).then((value) {

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -30,6 +30,8 @@ class _MyHomePageState extends State<MyHomePage> {
     'during a zombie outbreak. I am trying to escape from the zombies and get out of the city on a road bike, with the ultimate goal of getting to Alcatraz Island',
     'during a care bear convention. I am trying to do yoga with the care bears and spread love',
     'on the open seas swimming from Blackbeard the dreaded pirate and his bloodthirsty crew',
+    'during the Monarch butterfly migration. I am a Monarch butterfly trying to make it to Mexico',
+    'just before the asteroid impact that caused the dinosaurs to become extinct. I am a tiny mammal, trying to survive and find a mate',
   ];
 
   @override
@@ -74,8 +76,9 @@ class _MyHomePageState extends State<MyHomePage> {
             child: DropdownButton(
                 isExpanded: true,
                 value: story,
-                icon: const Icon(Icons.keyboard_arrow_down),    
+                icon: const Icon(Icons.keyboard_arrow_down),
                 items: items.map((String items) {
+                  // todo: Add a bullet or icon to make each item stand out?
                   return DropdownMenuItem(
                     value: items,
                     child: Text(items),
@@ -116,7 +119,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   // you'd often call a server or save the information in a database.
                   _formKey.currentState!.save();
                   List messages = [];
-                  String initialMessage = '''I would like you to play an interactive fiction game with me. You will tell a story, where I am the main character. At each decision point, youll stop and ask me what I do next. Please begin your prompt to me with “Decision time, $name". My answer will influence your next response. The story is set in $location. $story. My name is $name.''';
+                  String initialMessage = '''I would like you to play an interactive fiction game with me. You will tell a story, where I am the main character. At each decision point, youll stop and ask me what I do next. Please begin your prompt to me with “Decision time, $name". My answer will influence your next response. The story begins in $location $story. My name is $name.''';
                   OpenAi openAi = OpenAi();
                   messages.add({
                     'role': 'user',


### PR DESCRIPTION
Use ChatGPT to generate the Dall-E prompt. Improved error handling when fetching response. To avoid committing API keys, create a file called lib/auth/secrets.dart containing 'const String openaiApiKey = "API-KEY";'. .gitignore is rigged to ignore that file.